### PR TITLE
Fix CORS proxy data handling: use req.json() instead of req.text()

### DIFF
--- a/src/app/api/gas/route.ts
+++ b/src/app/api/gas/route.ts
@@ -39,12 +39,13 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const body = await req.text();
+    const data = await req.json();
+    console.log("proxy received data:", data);
 
     const res = await fetch(GAS_URL!, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body,
+      body: JSON.stringify(data),
     });
 
     const txt = await res.text();


### PR DESCRIPTION
- Changed await req.text() to await req.json() in POST function
- Added console logging to verify JSON data reception
- Resolves 'postData raw: no data' issue in GAS logs
- Frontend now successfully sends JSON data to GAS via CORS proxy
- Verified: proxy receives complete JSON payload with all form fields